### PR TITLE
debian file changes for minimal-style package.

### DIFF
--- a/debian/sid/debian/changelog
+++ b/debian/sid/debian/changelog
@@ -1,5 +1,5 @@
-chapel (1.13-1) unstable; urgency=low
+chapel-minimal (1.13.1-1) unstable; urgency=low
 
   * Initial release
 
- -- Ben Albrecht <balbrecht@cray.com>  Tue, 24 Nov 2015 23:35:55 +0000
+ -- Ben Albrecht <balbrecht@cray.com>  Fri, 15 Jul 2016 23:35:55 +0000

--- a/debian/sid/debian/control
+++ b/debian/sid/debian/control
@@ -1,19 +1,19 @@
-Source: chapel
+Source: chapel-minimal
 Section: devel
 Priority: optional
 Maintainer: Ben Albrecht <balbrecht@cray.com>
-Build-Depends: debhelper (>= 9), python2.7
+Build-Depends: debhelper (>= 9), python
 Standards-Version: 3.9.6
 Homepage: http://chapel.cray.com/
 
-Package: chapel
+Package: chapel-minimal
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}, libgmp-dev
-Description: Compiler for Chapel, a productive parallel programming language
- Emerging programming language designed for productive parallel
- computing at scale. Chapel's design and implementation have been undertaken
- with portability in mind, permitting Chapel to run on multicore desktops and
- laptops, commodity clusters, and the cloud, in addition to the high-end
- supercomputers for which it was designed. Chapel's design and development are
- being led by Cray Inc. in collaboration with academia, computing centers, and
- industry.
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}
+Description: Minimal compiler for the Chapel programming language
+ Minimal compiler without third-party dependencies for Chapel, an emerging
+ programming language designed for productive parallel computing at scale.
+ Chapel's design and implementation have been undertaken with portability in
+ mind, permitting Chapel to run on multicore desktops and laptops, commodity
+ clusters, and the cloud, in addition to the high-end supercomputers for which
+ it was designed. Chapel's design and development are being led by Cray Inc. in
+ collaboration with academia, computing centers, and industry.

--- a/debian/sid/debian/copyright
+++ b/debian/sid/debian/copyright
@@ -1,11 +1,11 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Files-Excluded: doc tools highlight third-party/fltk  third-party/gasnet  third-party/gmp  third-party/hwloc  third-party/jemalloc  third-party/libhdfs3  third-party/llvm  third-party/massivethreads  third-party/qthread  third-party/re2 third-party/chpl-venv/chpldoc-sphinx-project/.gitignore examples/benchmarks/isx/.gitignore
-
+Files-Excluded: doc tools highlight third-party/fltk  third-party/gasnet  third-party/gmp  third-party/hwloc  third-party/jemalloc  third-party/libhdfs3  third-party/llvm  third-party/massivethreads  third-party/qthread  third-party/re2 third-party/chpl-venv/chpldoc-sphinx-project/.gitignore examples/benchmarks/isx/.gitignore util/chplenv/template
 Upstream-Name: Chapel
 Upstream-Contact: Ben Albrecht <balbrecht@cray.com>
 Source: https://github.com/chapel-lang/chapel
+Comment: This is the minimal third-party free version of the package
 
-Files: *.md *.rst compiler runtime modules make man examples
+Files: *
 Copyright: 2004-2016 Ben Albrecht <balbrecht@cray.com>
 License: Apache
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,19 +25,23 @@ License: Apache
 
 
 Files: third-party/utf8-decoder
-Copyright: 2004-2016 Ben Albrecht <balbrecht@cray.com>
-License: BSD
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Copyright: 2008-2016 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+License: custom-license
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
  .
-     http://www.apache.org/licenses/LICENSE-2.0
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
  .
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- .
- On Debian systems, the complete text of the Apache License 2.0 can
- be found in "/usr/share/common-licenses/Apache-2.0"
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/debian/sid/debian/install
+++ b/debian/sid/debian/install
@@ -5,12 +5,7 @@ make                    /usr/lib/chapel/
 man                     /usr/lib/chapel/
 modules                 /usr/lib/chapel/
 runtime                 /usr/lib/chapel/
-third-party/chpl-venv   /usr/lib/chapel/third-party/
-third-party/hwloc       /usr/lib/chapel/third-party/
-third-party/jemalloc    /usr/lib/chapel/third-party/
-third-party/qthread     /usr/lib/chapel/third-party/
-third-party/re2         /usr/lib/chapel/third-party/
-third-party/utf8-decoder /usr/lib/chapel/third-party/
+third-party             /usr/lib/chapel/
 util/printchplenv       /usr/lib/chapel/util/
 util/chplenv            /usr/lib/chapel/util/
 ACKNOWLEDGEMENTS.md     /usr/lib/chapel/

--- a/debian/sid/debian/patches/remove-makefile-clean-tools.patch
+++ b/debian/sid/debian/patches/remove-makefile-clean-tools.patch
@@ -1,6 +1,6 @@
 Removed tools clean from Makefile (since we remove tools)
---- a/chapel-1.13.1/Makefile
-+++ b/chapel-1.13.1/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -165,7 +165,6 @@
  	cd modules && $(MAKE) clobber
  	cd runtime && $(MAKE) clobber

--- a/debian/sid/debian/patches/remove-third-parties-from-makefiles.patch
+++ b/debian/sid/debian/patches/remove-third-parties-from-makefiles.patch
@@ -1,6 +1,6 @@
 Remove all third-parties from Makefiles, to prevent errors for minimal version.
---- a/chapel-1.13.1/make/Makefile.base
-+++ b/chapel-1.13.1/make/Makefile.base
+--- a/make/Makefile.base
++++ b/make/Makefile.base
 @@ -143,16 +143,7 @@
  #
  THIRD_PARTY_DIR = $(CHPL_MAKE_HOME)/third-party
@@ -18,8 +18,8 @@ Remove all third-parties from Makefiles, to prevent errors for minimal version.
  
  -include $(THIRD_PARTY_DIR)/Makefile.devel.include
  
---- a/chapel-1.13.1/third-party/Makefile
-+++ b/chapel-1.13.1/third-party/Makefile
+--- a/third-party/Makefile
++++ b/third-party/Makefile
 @@ -15,43 +15,16 @@
  
  default: all

--- a/debian/sid/debian/patches/update-default-envs.patch
+++ b/debian/sid/debian/patches/update-default-envs.patch
@@ -1,6 +1,6 @@
 Changes CHPL_MEM, and CHPL_TASK defaults to cstdlib and fifo, respectively
---- a/chapel-1.13.1/util/chplenv/chpl_mem.py
-+++ b/chapel-1.13.1/util/chplenv/chpl_mem.py
+--- a/util/chplenv/chpl_mem.py
++++ b/util/chplenv/chpl_mem.py
 @@ -27,7 +27,7 @@
              if cygwin or pgi or gnu_darwin:
                  mem_val = 'cstdlib'
@@ -10,8 +10,8 @@ Changes CHPL_MEM, and CHPL_TASK defaults to cstdlib and fifo, respectively
      else:
          raise ValueError("Invalid flag: '{0}'".format(flag))
      return mem_val
---- a/chapel-1.13.1/util/chplenv/chpl_tasks.py
-+++ b/chapel-1.13.1/util/chplenv/chpl_tasks.py
+--- a/util/chplenv/chpl_tasks.py
++++ b/util/chplenv/chpl_tasks.py
 @@ -29,7 +29,7 @@
                  using_qthreads_incompatible_cce):
              tasks_val = 'fifo'

--- a/debian/sid/debian/rules
+++ b/debian/sid/debian/rules
@@ -2,11 +2,9 @@
 # -*- makefile -*-
 
 export DH_VERBOSE=1
-export CHPL_LIB_GMP=system
-export DEB_BUILD_OPTIONS="parallel=4"
 
 %:
-	dh $@ --with python2 --parallel
+	dh $@ --with python2
 
 override_dh_auto_test:
 


### PR DESCRIPTION
no lintian errors on sid!

Package ships as bare bones Chapel:
- No third-parties beyond utf8-decoder 
  - _why is this a third-party in the first place??_
- `CHPL_MEM = cstdlib`
- `CHPL_TASK = fifo`
