### PR TITLE
Fixed man pages, updated standards version, fixed python error

### DIFF
--- a/debian/sid/debian/chapel.manpages
+++ b/debian/sid/debian/chapel.manpages
@@ -1,1 +1,0 @@
-man/man1/chpl.1

--- a/debian/sid/debian/control
+++ b/debian/sid/debian/control
@@ -2,13 +2,13 @@ Source: chapel-minimal
 Section: devel
 Priority: optional
 Maintainer: Ben Albrecht <balbrecht@cray.com>
-Build-Depends: debhelper (>= 9), python
-Standards-Version: 3.9.6
+Build-Depends: debhelper (>= 9), python, dh-python
+Standards-Version: 3.9.8
 Homepage: http://chapel.cray.com/
 
 Package: chapel-minimal
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python:any (<< 2.8), python:any (>= 2.7.5-5~), python:any (>= 2.7~)
 Description: Minimal compiler for the Chapel programming language
  Minimal compiler without third-party dependencies for Chapel, an emerging
  programming language designed for productive parallel computing at scale.

--- a/debian/sid/debian/copyright
+++ b/debian/sid/debian/copyright
@@ -1,5 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Files-Excluded: doc tools highlight third-party/fltk  third-party/gasnet  third-party/gmp  third-party/hwloc  third-party/jemalloc  third-party/libhdfs3  third-party/llvm  third-party/massivethreads  third-party/qthread  third-party/re2 third-party/chpl-venv/chpldoc-sphinx-project/.gitignore examples/benchmarks/isx/.gitignore util/chplenv/template
+Files-Excluded: doc tools highlight third-party/fltk  third-party/gasnet  third-party/gmp  third-party/hwloc  third-party/jemalloc  third-party/libhdfs3  third-party/llvm  third-party/massivethreads  third-party/qthread  third-party/re2 third-party/chpl-venv/chpldoc-sphinx-project/.gitignore examples/benchmarks/isx/.gitignore util/chplenv/template examples
 Upstream-Name: Chapel
 Upstream-Contact: Ben Albrecht <balbrecht@cray.com>
 Source: https://github.com/chapel-lang/chapel
@@ -24,7 +24,7 @@ License: Apache
  be found in "/usr/share/common-licenses/Apache-2.0"
 
 
-Files: third-party/utf8-decoder
+Files: third-party/utf8-decoder/*
 Copyright: 2008-2016 Bjoern Hoehrmann <bjoern@hoehrmann.de>
 License: custom-license
  Permission is hereby granted, free of charge, to any person obtaining

--- a/debian/sid/debian/install
+++ b/debian/sid/debian/install
@@ -1,11 +1,11 @@
 bin                     /usr/lib/chapel/
-examples                /usr/lib/chapel/
 lib                     /usr/lib/chapel/
-make                    /usr/lib/chapel/
-man                     /usr/lib/chapel/
 modules                 /usr/lib/chapel/
 runtime                 /usr/lib/chapel/
 third-party             /usr/lib/chapel/
+make/Makefile.base      /usr/lib/chapel/make/
+make/platform           /usr/lib/chapel/make/
+make/tasks              /usr/lib/chapel/make/
 util/printchplenv       /usr/lib/chapel/util/
 util/chplenv            /usr/lib/chapel/util/
 ACKNOWLEDGEMENTS.md     /usr/lib/chapel/

--- a/debian/sid/debian/rules
+++ b/debian/sid/debian/rules
@@ -11,4 +11,3 @@ override_dh_auto_test:
 
 override_dh_auto_clean:
 	dh_auto_clean -- clobber
-

--- a/debian/test.sh
+++ b/debian/test.sh
@@ -13,8 +13,10 @@ cd ${DEBIAN_RELEASE}
 
 ### Package Quality ###
 echo "Generating lintian logs"
-lintian ${DEB} > ../cache/deb-lint.log
-lintian ${DSC} > ../cache/dsc-lint.log
+LINTFLAGS="-I --show-overrides"
+lintian ${LINTFLAGS} ${DEB} > ../cache/deb-lint.log
+lintian ${LINTFLAGS} ${DSC} > ../cache/dsc-lint.log
+lintian ${LINTFLAGS} ${CHANGES} > ../cache/changes-lint.log
 
 # Information about package
 echo "Generating package information log"
@@ -27,11 +29,12 @@ sudo dpkg -i ${DEB}
 
 which ${BINARY}
 
-${BINARY} --help
+${BINARY} --version
 
-ls -R /usr/lib/${PKG}
+echo "Package contents:"
+ls -R /usr/lib/chapel > ../cache/pkg-contents.log
 
-ls -l /usr/bin/${BINARY}
+ls -l /usr/bin/${BINARY} >> ../cache/pkg-contents.log
 
 set +x
 


### PR DESCRIPTION
- Fixed man pages
- Updated standards-version
- Fixed Python lintian errors
  - Still getting left-over *.pyc files (fix coming in near-future PR)
- Pruned some unnecessary Makefiles from install
- Updated `test.sh` to do what `mentors.debian.net` does.
