### PR TITLE
Fix pbuilder build

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -48,3 +48,27 @@ Not executable.
 
 Contains all the variables necessary for other scripts. See the default values
 here.
+
+
+## FAQ
+
+### How do I build with pbuilder?
+
+
+Install pbuilder:
+
+```
+sudo apt install pbuilder
+```
+
+Build the package with `./build.sh`
+
+
+Run pbuilder on the source package:
+
+```
+cd sid/
+sudo pbuilder --build chapel-1.16_1.16.0-1.dsc
+```
+
+

--- a/debian/sid/debian/chapel-doc-1.16.install
+++ b/debian/sid/debian/chapel-doc-1.16.install
@@ -1,3 +1,3 @@
 doc/debian/README.rst  usr/share/doc/chapel/1.16
 doc/rst  usr/share/doc/chapel/1.16
-examples usr/share/doc/chapel/1.16
+deb-examples/* usr/share/doc/chapel/1.16/examples

--- a/debian/sid/debian/copyright
+++ b/debian/sid/debian/copyright
@@ -9,24 +9,21 @@ Files-Excluded: doc/html
                 third-party/fltk/fl_line_style.cxx
                 third-party/fltk/fltk-1.3.3-source.tar.gz
                 third-party/gasnet/gasnet-src
-                third-party/gmp/gmp-6.0.0a.tar.bz2
+                third-party/gmp/gmp-src
                 third-party/hwloc/hwloc-src
                 third-party/jemalloc/jemalloc-src
                 third-party/libhdfs3/fetch-libhdfs3.sh
                 third-party/libunwind/libunwind-1.1.tar.gz
-                third-party/llvm/cfe-3.7.0.src.tar.xz
+                third-party/llvm/cfe-4.0.1.src.tar.xz
                 third-party/llvm/cmake-ok.sh
                 third-party/llvm/COMPILERONLY
                 third-party/llvm/find-llvm-config.sh
-                third-party/llvm/llvm-3.7.0.src.tar.xz
+                third-party/llvm/llvm-4.0.1.src.tar.xz
                 third-party/llvm/unpack-llvm.sh
                 third-party/llvm/update-llvm.sh
                 third-party/massivethreads/massivethreads-src
                 third-party/qthread/qthread-src/
-                third-party/re2/re2
-                third-party/re2/re2-20140111.tgz
-                third-party/re2/unpack-re2.sh
-                third-party/re2/update-re2.sh
+                third-party/re2/re2-src
 Upstream-Name: Chapel
 Upstream-Contact: Ben Albrecht <balbrecht@cray.com>
 Source: https://github.com/chapel-lang/chapel

--- a/debian/sid/debian/rules
+++ b/debian/sid/debian/rules
@@ -2,14 +2,14 @@
 # -*- makefile -*-
 
 export DH_VERBOSE=1
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export CHPL_CHECK_INSTALL_DIR = ${TMPDIR}
+export DEB_BUILD_MAINT_OPTIONS=hardening=+all
+export CHPL_CHECK_INSTALL_DIR=${TMPDIR}
 
 %:
 	bash -c 'source util/quickstart/setchplenv.bash ; dh $@ --parallel'
 
 override_dh_auto_test:
-	bash -c 'source util/quickstart/setchplenv.bash ; $(MAKE) check'
+	bash -c 'source util/quickstart/setchplenv.bash ;  $(MAKE) check'
 
 override_dh_auto_configure:
 	bash -c 'source util/quickstart/setchplenv.bash ; bash ./configure --prefix=/usr'
@@ -17,9 +17,11 @@ override_dh_auto_configure:
 # examples: let it contain .chpl, README files only
 # README.testing is removed because we removed the other testing files
 	find examples/ -name '*.chpl' -o -name 'README*' -and -not -name README.testing | tar cvzf examples.tgz --files-from -
-	rm -Rf examples
+	mv examples examples-save
 	tar xvzf examples.tgz
 	rm -Rf examples.tgz
+	mv examples deb-examples
+	mv examples-save examples
 # util/chplenv/template is for developers
 	rm -f util/chplenv/template
 

--- a/debian/sid/debian/source.lintian-overrides
+++ b/debian/sid/debian/source.lintian-overrides
@@ -1,2 +1,0 @@
-# This is an error with a third-party license (GMP):
-chapel-1.16 source: license-problem-gfdl-invariants *


### PR DESCRIPTION
- Update some outdated install paths (notably `gmp-src`, which was causing a lintian error)
- Keep `examples/` testing files around so that `make check` succeeds
- Add guide for people trying to reproduce `pbuilder` build
- Remove extra white space in `rules` file out of superstition