### PR TITLE
Fix problem building package on newer Debian

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -61,6 +61,12 @@ Install pbuilder:
 sudo apt install pbuilder
 ```
 
+Create a pbuilder chroot environment:
+```
+sudo pbuilder create
+```
+(later you might run `sudo pbuilder update` to update the chroot environment).
+
 Build the package with `./build.sh`
 
 

--- a/debian/sid/debian/patches/makecheckj.patch
+++ b/debian/sid/debian/patches/makecheckj.patch
@@ -1,0 +1,18 @@
+Description: Add + to make check target
+ This is required for the package to check
+Author: Ben Albrecht <balbrecht@cray.com>
+Forwarded: not-needed
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/Makefile
++++ b/Makefile
+@@ -185,7 +185,7 @@
+ 	@echo "make depend has been deprecated for the time being"
+ 
+ check:
+-	@CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
++	+@CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
+ 
+ check-chpldoc: chpldoc third-party-test-venv
+ 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc
+

--- a/debian/sid/debian/patches/series
+++ b/debian/sid/debian/patches/series
@@ -1,3 +1,4 @@
 acknowledge-cppflags.patch
 chplconfig
 add-docs-rst-readme
+makecheckj.patch

--- a/debian/sid/debian/rules
+++ b/debian/sid/debian/rules
@@ -3,13 +3,22 @@
 
 export DH_VERBOSE=1
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
+# Set TMPDIR if it's not already set
+TMPDIR ?= /tmp
 export CHPL_CHECK_INSTALL_DIR=${TMPDIR}
 
 %:
 	bash -c 'source util/quickstart/setchplenv.bash ; dh $@ --parallel'
 
 override_dh_auto_test:
-	bash -c 'source util/quickstart/setchplenv.bash ;  $(MAKE) check'
+	+bash -c 'source util/quickstart/setchplenv.bash ;  $(MAKE) -s check'
+
+
+# The following is an alternative basic test:
+	#bash -c 'source util/quickstart/setchplenv.bash ;  chpl examples/hello.chpl > hello.comp.out 2>&1; ./hello > hello.exec.out 2>&1; rm hello'
+	#cat hello.comp.out
+	#cat hello.exec.out
+	#diff hello.exec.out examples/hello.good
 
 override_dh_auto_configure:
 	bash -c 'source util/quickstart/setchplenv.bash ; bash ./configure --prefix=/usr'


### PR DESCRIPTION
The make check step was getting messed up by additional Make output. This PR fixes that by quieting a make -j error and also the entering/exiting directory output. These were getting included in the compilation output.

The make check j patch is also here:
 https://github.com/chapel-lang/chapel/pull/8808

With these changes, I'm able to build the package with pbuilder. 

Reviewed by @ben-albrecht .